### PR TITLE
Better run times for pull request action

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -6,24 +6,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    container: ghcr.io/uvidyadharan/ftcdocs-build:0.1
     steps:
       - name: Checkout Repository  
         uses: actions/checkout@v2
-        
-      - name: Run Tune
-        uses: abbbi/github-actions-tune@v1
-        
-      - name: Refresh Packages
-        run: sudo apt-fast -y update
-        
-      - name: Install Dependencies
-        run: sudo apt-fast install -y texlive-xetex latexmk
-        
-      - name: Python Setup
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.8
-          cache: 'pip'
         
       - name: Python Install Dependencies
         run: pip install -r docs/requirements.txt


### PR DESCRIPTION
Uses docker container with dependencies  preinstalled for significant cutdown in build time. Dockerfile attached below. If used, image should be uploaded to ftcdocs container registry. This will also prevent updates to  dependencies from disrupting workflow.

Dockerfile: 
```Dockerfile
FROM python:3.9.13-slim-bullseye
RUN apt update && apt install -y python3-pip texlive-xetex latexmk
```