### PR TITLE
Clean up HTML and PDF versions

### DIFF
--- a/docs/source/game_specific_resources/playing_field_resources/playing_field_resources.rst
+++ b/docs/source/game_specific_resources/playing_field_resources/playing_field_resources.rst
@@ -15,7 +15,9 @@ in the official field drawings. The base field stays the same for all games but 
 Traditional Field Setup Guide
 ------------------------------------
 
-`Traditional Field Setup Guide <https://www.firstinspires.org/sites/default/files/uploads/resource_library/ftc/field-setup-guide.pdf>`__
+.. only:: latex
+
+    `Traditional Field Setup Guide <https://www.firstinspires.org/sites/default/files/uploads/resource_library/ftc/field-setup-guide.pdf>`__
 
 .. raw:: html
 
@@ -26,7 +28,9 @@ Traditional Field Setup Guide
 Remote Field Setup Guide
 ------------------------------------
 
-`Remote Field Setup Guide <https://firstinspiresst01.blob.core.windows.net/first-forward-ftc/remote-field-requirements.pdf>`__
+.. only:: latex
+
+    `Remote Field Setup Guide <https://firstinspiresst01.blob.core.windows.net/first-forward-ftc/remote-field-requirements.pdf>`__
 
 .. raw:: html
 

--- a/docs/source/manuals/game_manuals/game_manuals.rst
+++ b/docs/source/manuals/game_manuals/game_manuals.rst
@@ -1,14 +1,18 @@
 Game Manuals
 ============
 
-Game Manuals can be found on the `Game and Season Materials page <https://www.firstinspires.org/resource-library/ftc/game-and-season-info>`__ on the *FIRST* Website. They are presented here in frames for your convenience.
+Game Manuals can be found on the `Game and Season Materials page <https://www.firstinspires.org/resource-library/ftc/game-and-season-info>`__ on the *FIRST* Website. They are presented here for your convenience.
 
-.. tip:: To search all four PDFs at once, just perform a search within this webpage for the content you are looking for. Then simply scroll down to each PDF to see which PDFs contained the content you were looking for!
+.. only:: html
+
+    .. tip:: To search all four PDFs at once, just perform a search within this webpage for the content you are looking for. Then simply scroll down to each PDF to see which PDFs contained the content you were looking for!
 
 Game Manual Part 1 Traditional Events
 -------------------------------------
 
-`Game Manual Part 1 Traditional Events <https://www.firstinspires.org/sites/default/files/uploads/resource_library/ftc/game-manual-part-1-traditional-events.pdf>`__
+.. only:: latex
+
+    `Game Manual Part 1 Traditional Events <https://www.firstinspires.org/sites/default/files/uploads/resource_library/ftc/game-manual-part-1-traditional-events.pdf>`__
 
 .. raw:: html
 
@@ -19,7 +23,9 @@ Game Manual Part 1 Traditional Events
 Game Manual Part 2 Traditional Events
 -------------------------------------
 
-`Game Manual Part 2 Traditional Events <https://firstinspiresst01.blob.core.windows.net/first-forward-ftc/game-manual-part-2-traditional.pdf>`__
+.. only:: latex
+
+    `Game Manual Part 2 Traditional Events <https://firstinspiresst01.blob.core.windows.net/first-forward-ftc/game-manual-part-2-traditional.pdf>`__
 
 .. raw:: html
 
@@ -30,7 +36,9 @@ Game Manual Part 2 Traditional Events
 Game Manual Part 1 Remote Events
 --------------------------------
 
-`Game Manual Part 1 Remote Events <https://www.firstinspires.org/sites/default/files/uploads/resource_library/ftc/game-manual-part-1-remote-events.pdf>`__
+.. only:: latex
+
+    `Game Manual Part 1 Remote Events <https://www.firstinspires.org/sites/default/files/uploads/resource_library/ftc/game-manual-part-1-remote-events.pdf>`__
 
 .. raw:: html
 
@@ -41,7 +49,9 @@ Game Manual Part 1 Remote Events
 Game Manual Part 2 Remote Events
 --------------------------------
 
-`Game Manual Part 2 Remote Events <https://www.firstinspires.org/sites/default/files/uploads/resource_library/ftc/game-manual-part-2-remote.pdf>`__
+.. only:: latex
+
+    `Game Manual Part 2 Remote Events <https://www.firstinspires.org/sites/default/files/uploads/resource_library/ftc/game-manual-part-2-remote.pdf>`__
 
 .. raw:: html
 

--- a/docs/source/overview/ftcoverview.rst
+++ b/docs/source/overview/ftcoverview.rst
@@ -18,6 +18,10 @@ enlistment, and other employment pathways.
 Each season concludes with regional championship events and an exciting `FIRST
 Championship <https://www.firstchampionship.org/>`__.
 
+.. only:: latex
+
+   `About FIRST Tech Challenge (2021) <https://www.youtube.com/embed/y5NPp_5KHuk>`__
+
 .. raw:: html
 
    <iframe width="100%" height="452" src="https://www.youtube.com/embed/y5NPp_5KHuk" title="About FIRST Tech Challenge (2021)" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>


### PR DESCRIPTION
Switch to using `.. only::` directive for PDFs and videos. It should be noted that to avoid fragmentation it should only be used in specific standardized use cases such as PDFs and Videos both of which use iframes.  