### PR TITLE
Added Link To FtcRobotController Github Repo To Front Page

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -193,6 +193,16 @@ students. It’s way more than building robots, see
                TensorFlow in POWERPLAY
 
          .. div:: col-sm pl-1 pr-1
+
+            .. button-ref:: https://github.com/FIRST-Tech-Challenge/FtcRobotController
+               :ref-type: doc
+               :color: black
+               :outline:
+               :expand:
+
+               FtcRobotController Github Page
+
+         .. div:: col-sm pl-1 pr-1
  
             .. button-ref:: programming_resources/index
                :ref-type: doc


### PR DESCRIPTION
I added a link to the FtcRobotController Github Repo. I think it is an important resource that should be on there. The link is buried a little bit on the website so I thought I would place a nice quick link to it. My team was updating my phones and I was surprised this wasn't on the front page as I think it would be an important link to be front and center. Thank you for the great work you all have done on this! I'm impressed and have shared it with my team!