### PR TITLE
Fix header on Android Studio page

### DIFF
--- a/docs/source/programming_resources/tutorial_specific/android_studio/downloading_as_project_folder/Downloading-the-Android-Studio-Project-Folder.rst
+++ b/docs/source/programming_resources/tutorial_specific/android_studio/downloading_as_project_folder/Downloading-the-Android-Studio-Project-Folder.rst
@@ -48,8 +48,12 @@ this **Assets** section.
 |
 
 Click on the Source code (zip) link to download the compressed Android
-Studio project folder. ### Extracting the Contents of the Archived
-Project File Once you have downloaded the archived (.ZIP) project file
+Studio project folder.
+
+Extracting the Contents of the Archived Project File
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Once you have downloaded the archived (.ZIP) project file
 you can move this file to the location of your choice.
 
 .. image:: images/MoveDownloadedFile.jpg


### PR DESCRIPTION
After fixing #138, I found another header that didn't convert from Markdown to RST. This fixes that header too.