### PR TITLE
Stop the extraneous linkcheck chatter

### DIFF
--- a/.github/workflows/link-check.yaml
+++ b/.github/workflows/link-check.yaml
@@ -22,7 +22,7 @@ jobs:
         run: pip install -r docs/requirements.txt
 
       - name: link-check
-        run: make -C docs/ linkcheck SPHINXOPTS="-W --keep-going -n"
+        run: make -C docs/ linkcheck SPHINXOPTS="-W --keep-going -n -q"
 
       - name: Arhive Log
         if: ${{ failure() }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -78,7 +78,7 @@ jobs:
         run: pip install -r docs/requirements.txt
 
       - name: link-check
-        run: make -C docs/ linkcheck SPHINXOPTS="-W --keep-going -n"
+        run: make -C docs/ linkcheck SPHINXOPTS="-W --keep-going -n -q"
 
       - name: Archive Log
         if: ${{ failure() }}


### PR DESCRIPTION
Results in, when there's a broken link, only the error being output to the console.

```
$ make linkcheck SPHINXOPTS="-W --keep-going -n -q"
C:\FIRST\dev\ftcdocs\docs\source\programming_resources\imu\imu.rst:7: WARNING: broken link: https://www.bosch-sensortec.com/products/smart-sensors/bno055/ (500 Server Error: Internal Server Error for url: https://www.bosch-sensortec.com/products/smart-sensors/bno055/)
C:\FIRST\dev\ftcdocs\docs\source\programming_resources\imu\imu.rst:7: WARNING: broken link: https://www.bosch-sensortec.com/products/smart-sensors/bhi260ap/ (500 Server Error: Internal Server Error for url: https://www.bosch-sensortec.com/products/smart-sensors/bhi260ap/)
make: *** [Makefile:40: linkcheck] Error 1
```

As opposed to the hundreds of "ok" messages that only served to obscure the broken links a developer might be trying to find.
