### PR TITLE
Add Cookie Banner

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,4 @@ git+https://github.com/FIRST-Tech-Challenge/ftcdocs-helper@main#subdirectory=sph
 git+https://github.com/FIRST-Tech-Challenge/ftcdocs-helper@main#subdirectory=javasphinx
 sphinx_design==0.2.0
 git+https://github.com/FIRST-Tech-Challenge/ftcdocs-helper@main#subdirectory=googleanalytics
+git+https://github.com/FIRST-Tech-Challenge/ftcdocs-helper@main#subdirectory=cookiebanner

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,9 +35,6 @@ todo_include_todos = False
 # Configure Google Analytics, Disabled by default
 googleanalytics_enabled = False
 
-# Cookiebanner Enable
-cookiebanner_enabled = True
-
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'sphinx': ('https://www.sphinx-doc.org/en/master/', None),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,6 +35,9 @@ todo_include_todos = False
 # Configure Google Analytics, Disabled by default
 googleanalytics_enabled = False
 
+# Ensure Cookie Banner is Enabled
+cookiebanner_enabled = True
+
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'sphinx': ('https://www.sphinx-doc.org/en/master/', None),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,6 +35,7 @@ todo_include_todos = False
 # Configure Google Analytics, Disabled by default
 googleanalytics_enabled = False
 
+# Cookiebanner Enable
 cookiebanner_enabled = True
 
 intersphinx_mapping = {

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,6 +25,7 @@ extensions = [
     'sphinx_design',
     'sphinx_rtd_dark_mode',
     'sphinxcontrib.googleanalytics',
+    'sphinxcontrib.cookiebanner',
 ]
 
 autosectionlabel_prefix_document = True
@@ -159,6 +160,7 @@ if(os.environ.get("DOCS_BUILD") == "true"):
     # Configure Google Analytics
     googleanalytics_id = os.environ.get("GOOGLE_ANALYTICS_ID") 
     googleanalytics_enabled = os.environ.get("GOOGLE_ANALYTICS_ID", default = "") != ""
+    cookiebanner_enabled = os.environ.get("COOKIEBANNER", default = "") != ""
 
 # Configure RTD Theme
 html_theme_options = {

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@ extensions = [
     'sphinx_design',
     'sphinx_rtd_dark_mode',
     'sphinxcontrib.googleanalytics',
-    'sphinxcontrib.cookiebanner',
+    'sphinxcontrib.cookiebanner', 
 ]
 
 autosectionlabel_prefix_document = True

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,9 +35,6 @@ todo_include_todos = False
 # Configure Google Analytics, Disabled by default
 googleanalytics_enabled = False
 
-# Ensure Cookie Banner is Enabled
-cookiebanner_enabled = True
-
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'sphinx': ('https://www.sphinx-doc.org/en/master/', None),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,6 +35,8 @@ todo_include_todos = False
 # Configure Google Analytics, Disabled by default
 googleanalytics_enabled = False
 
+cookiebanner_enabled = True
+
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'sphinx': ('https://www.sphinx-doc.org/en/master/', None),


### PR DESCRIPTION
This PR attempts to add a Cookie Banner to the website that provides information and acknowledgment about the cookie policy in the [FIRST Privacy Policy](https://www.firstinspires.org/about/privacy-policy). This attempts to satisfy GDPR and other related cookie laws/regulations/policies.

This is using a custom Sphinx extension written by Danny Diaz (me) that uses/inserts banner javascript into the source of the page. The module actually uses https://github.com/osano/cookieconsent as the source of the banner. The Sphinx extension can be found here:
https://github.com/FIRST-Tech-Challenge/ftcdocs-helper/tree/main/cookiebanner

The finished banner, when it pops up, looks like this:
![image](https://user-images.githubusercontent.com/5846611/208267781-12ccbfd4-a18e-4e7b-a85d-b9db63da138a.png)

"Learn More" is a link that links to the FIRST Privacy Policy.
The user is merely given the opportunity to say "Got it!" to acknowledge the fact that the site uses cookies, as the text says.

The acknowledgement of the cookie banner is stored as a non-expiring cookie, preventing the banner from being shown again.