### PR TITLE
Update Link Checker user agent

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -111,7 +111,7 @@ sphinx_tabs_valid_builders = ["epub", "linkcheck"]
 epub_show_urls = 'footnote'
 
 # Specify a standard user agent, as Sphinx default is blocked on some sites
-#user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36"
+user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36"
 
 # Change request header to avoid 403 error because Solidworks is great like that
 linkcheck_request_headers = {


### PR DESCRIPTION
The standard Link Checker user agent is old, and some websites now forbid those checkers from accessing (especially for CAD tools where that "browser" is no longer supported). Need to keep the user agent up-to-date to keep sites from messing with the link checker.