### PR TITLE
Harden Link Check

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -111,7 +111,10 @@ sphinx_tabs_valid_builders = ["epub", "linkcheck"]
 epub_show_urls = 'footnote'
 
 # Specify a standard user agent, as Sphinx default is blocked on some sites
-user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36"
+user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36"
+
+# Add a timeout to linkcheck to prevent check from simply hanging on poor websites
+linkcheck_timeout = 15
 
 # Change request header to avoid 403 error because Solidworks is great like that
 linkcheck_request_headers = {
@@ -121,10 +124,14 @@ linkcheck_request_headers = {
 }
 
 # Firstinspires redirects to login and break our link checker :)
+# ftc-ml.firstinspires.org does a redirect that linkcheck hates.
+# GitHub links with Javascript Anchors cannot be detected by linkcheck
+# Solidworks returns 403 errors on too many web pages. Thanks, buddy.
 linkcheck_ignore = [
    r'https://my.firstinspires.org/Dashboard/', 
    "https://ftc-ml.firstinspires.org",
-   r'https://github.com/.*#'
+   r'https://github.com/.*#',
+   r'https://www.solidworks.com/'
 ]
 
 latex_documents = [

--- a/docs/source/tos/tos.rst
+++ b/docs/source/tos/tos.rst
@@ -9,7 +9,7 @@ Agreement to Terms
 These Terms of Use constitute a legally binding agreement made between you, whether
 personally or on behalf of an entity (“you”) and *FIRST* (“Company”, “we”, “us”, or “our”),
 concerning your access to and use of the 
-`http://www.firstinspires.org <http://www.firstinspires.org>`_ website as well as any
+`https://www.firstinspires.org/ <https://www.firstinspires.org/>`_ website as well as any
 other media form, media channel, mobile website or mobile application related, linked, or
 otherwise connected thereto (collectively, the “Site” or “Sites”). You agree that by accessing the
 Site, you have read, understood, and agreed to be bound by these Terms of Use.


### PR DESCRIPTION
A number of things done to the conf.py file to harden the link checker:
(1) Added comments about linkcheck exceptions
(2) Added Solidworks to linkcheck exceptions - I'm tired of dealing with 403 errors from that website.
(3) Added 15s timeout to linkcheck to prevent it from hanging forever and not showing what made it hang. Now worse-case it "hangs" on a single element for no more than 15 seconds, and then shows what it failed on.
(4) Updated the user-agent. Maybe not necessary, but it's the recommended browser we're checking links against.
