### PR TITLE
Fix conf.py problems

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -178,11 +178,6 @@ if(os.environ.get("RTD_DOCS_BUILD") == "true"):
     extensions.append('sphinx_sitemap')
     html_baseurl = os.environ.get("FTCDOCS_URL", default="")
 
-    html_context = dict()
-    html_context['github_user'] = 'FIRST-Tech-Challenge'
-    html_context['github_repo'] = 'ftcdocs'
-    html_context['github_version'] = 'main/docs/source/'
-
 # Configure RTD Theme
 html_theme_options = {
     'navigation_depth': 5,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -154,6 +154,9 @@ def setup(app):
     #app.add_css_file("css/ftc-rtl.css")
     app.add_js_file("js/external-links-new-tab.js")
 
+# Set Cookie Banner to disabled by default
+cookiebanner_enabled = False
+
 # Configure for local official-esque builds
 if(os.environ.get("LOCAL_DOCS_BUILD") == "true"):
     html_context = dict()


### PR DESCRIPTION
#184  broke the edit on GitHub link. This fixes it. Current translation solution no longer requires the link to be hard set.

Cookiebanner is now set to be disabled by default. It is enabled on the official build where we collect google analytics data.