### PR TITLE
Add note re. FTC app versions to Self Inspect article

### DIFF
--- a/docs/source/hardware_and_software_configuration/self_inspect/self-inspect.rst
+++ b/docs/source/hardware_and_software_configuration/self_inspect/self-inspect.rst
@@ -27,8 +27,8 @@ Self Inspect layout and graphics evolve with FTC requirements; this page
 clarifies some of the brief but meaningful captions.
 
 .. note::
-  These images show Version 7.0 of the FTC apps. As of January 2024, 
-  the required minimum is Version 9.0 for the CENTERSTAGE season.
+  These images show Version 7.0 of the FTC apps. Please refer to Game Manual 
+  Part 1 for the correct allowed software system versions.
 
 Device Pairing
 --------------

--- a/docs/source/hardware_and_software_configuration/self_inspect/self-inspect.rst
+++ b/docs/source/hardware_and_software_configuration/self_inspect/self-inspect.rst
@@ -26,6 +26,10 @@ The challenge is to maximize useful information in a small screen. The
 Self Inspect layout and graphics evolve with FTC requirements; this page
 clarifies some of the brief but meaningful captions.
 
+.. note::
+  These images show Version 7.0 of the FTC apps. As of January 2024, 
+  the required minimum is Version 9.0 for the CENTERSTAGE season.
+
 Device Pairing
 --------------
 


### PR DESCRIPTION
At the request of Mr. Phil Malone ([@gearsincorg](https://github.com/gearsincorg)), please add the following note to the end of the Introduction of [this ftc-docs page](https://ftc-docs.firstinspires.org/en/latest/hardware_and_software_configuration/self_inspect/self-inspect.html):

Note: These images show Version 7.0 of the FTC apps. As of January 2024, the required minimum is Version 9.0 for the CENTERSTAGE season.

This was implemented also at the [ftc wiki](https://github.com/FIRST-Tech-Challenge/FtcRobotController/wiki/FTC-Self-Inspect).