### PR TITLE
Resolve linkcheck issues

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -245,7 +245,7 @@ user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTM
 
 # Add a timeout to linkcheck to prevent check from simply hanging on poor websites
 
-linkcheck_timeout = 30
+linkcheck_timeout = 60
 
 # Change request header to avoid timeout errors with SOLIDWORKS/Autodesk because they are great like that
 

--- a/docs/source/control_hard_compon/rc_components/hub/ports/std-ports.rst
+++ b/docs/source/control_hard_compon/rc_components/hub/ports/std-ports.rst
@@ -56,7 +56,7 @@ These 0.1” Header pins are used to power and control various appliances. There
 are two ports on each hub. These connectors can be used for a limited range of
 applications in FIRST Tech Challenge, such as powering powered USB hubs. For more
 information on this port please see 
-`REV +5V Power Port Documentation <https://docs.revrobotics.com/duo-control/control-system-overview/control-hub-basics#+5v-power-port-specifications>`_ and 
+`REV +5V Power Port Documentation <https://docs.revrobotics.com/duo-control/control-system-overview/control-hub-basics#id-5v-power-port-specifications>`_ and 
 :ref:`Game Manual Part 1 <manuals/game_manuals/game_manuals:game manuals>`.
 
 Analog Ports


### PR DESCRIPTION
Fix broken REV link
Increase timeout to 60 seconds to accommodate slow Javadoc's loading times. 