### PR TITLE
Change enableCameraMonitoring to enableLiveView

### DIFF
--- a/docs/source/apriltag/vision_portal/visionportal_init/visionportal-init.rst
+++ b/docs/source/apriltag/vision_portal/visionportal_init/visionportal-init.rst
@@ -125,7 +125,7 @@ Comments are omitted here, to clearly illustrate the chaining.
        .addProcessor(myAprilTagProcessor)
        .setCameraResolution(new Size(640, 480))
        .setStreamFormat(VisionPortal.StreamFormat.YUY2)
-       .enableCameraMonitoring(true)
+       .enableLiveView(true)
        .setAutoStopLiveView(true)
        .build();
 


### PR DESCRIPTION
The FTCDocs say to use "enableCameraMonitoring(boolean)" on a VisionPortal.Builder to enable/disable live view, but the SDK seems to have changed this to be "enableLiveView(boolean)" in the 9.0 and later releases.