### PR TITLE
Update visionportal-cpu-and-bandwidth.rst

### DIFF
--- a/docs/source/apriltag/vision_portal/visionportal_cpu_and_bandwidth/visionportal-cpu-and-bandwidth.rst
+++ b/docs/source/apriltag/vision_portal/visionportal_cpu_and_bandwidth/visionportal-cpu-and-bandwidth.rst
@@ -159,7 +159,7 @@ LiveView **in general**, available in Blocks and Java:
 
 .. code-block:: java
 
-   builder.enableCameraMonitoring(true);
+   builder.enableLiveView(true);
 
 Sample OpModes set this Builder field to ``true`` by default.
 


### PR DESCRIPTION
SDK 9.0 seems to use "enableLiveView(boolean)" instead of "enableCameraMonitoring(boolean)".