### PR TITLE
Add an action to delete stale artifacts

### DIFF
--- a/.github/workflows/artifact-management.yaml
+++ b/.github/workflows/artifact-management.yaml
@@ -1,0 +1,17 @@
+name: "Artifact Management"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '15 8 1 * *'
+
+jobs:
+  delete-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dscaba/purge-artifacts-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          expire-in: 7days
+          
+


### PR DESCRIPTION
Designed to automate the task of deleting stale artifacts and thereby avoid the periodic email GitHub sends regarding warnings of pending artifact storage exhaustion.

Runs on the first day of every month at 8:15 UTC, or 12:15am PST.  Deletes everything over 7 days old.