### PR TITLE
remove reference to the 2022-23 season kickoff

### DIFF
--- a/docs/source/cad_resources/solidworks/solidworks.rst
+++ b/docs/source/cad_resources/solidworks/solidworks.rst
@@ -10,16 +10,7 @@ collaborative robot design with your team.
 Obtaining SOLIDWORKS® Software
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Dassault Systèmes makes select software available to all *FIRST* teams. 
-
-.. note:: As of the 2022-2023 season, Dassault Systèmes is changing their software application process. **More Details to be announced by Kickoff**. All teams who would like to request software should create a 3DEXPERIENCE ID regardless of whether you're requesting desktop or cloud-based software.
-
-Dassault Systèmes provides both cloud-based and desktop-based tools to *FIRST*
-teams. Teams must:
-
-1.  `Create a 3DEXPERIENCE ID <https://eu1-ds-iam.3dexperience.3ds.com/login>`__
-    if you don't have one.
-2.  Apply to request your license (**more details coming soon**).
+Dassault Systèmes makes select software available to all *FIRST* teams. Dassault Systèmes provides both cloud-based and desktop-based tools. Visit https://www.solidworks.com/product/students/first-robotics-students to learn how to set up an account. 
 
 SOLIDWORKS® Training Videos
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Closes https://github.com/FIRST-Tech-Challenge/ftcdocs-private/issues/93 

Solidworks page references an update coming after the 202-23 kickoff which has been removed and replaced with the correct supplier page.