### PR TITLE
remove iframe to fix keyboard tab trap.

### DIFF
--- a/docs/source/game_specific_resources/playing_field_resources/playing_field_resources.rst
+++ b/docs/source/game_specific_resources/playing_field_resources/playing_field_resources.rst
@@ -2,25 +2,54 @@ Playing Field Resources
 =======================
 
 .. figure:: images/CenterStageField.png
+   :alt: Arena with four teams in alliances areas. Four robots are on the field along with CENTERSTAGE game elements.
     
-    Traditional Playing Field ~ CENTERSTAGE presented by RTX, 2023-2024
+   Traditional Playing Field, CENTERSTAGE presented by RTX, 2023-2024
 
 About the Playing Field
-------------------------------------
-There are multiple configurations of the playing field that can be used. For traditional games, the playing field is a part of the Competition Area that includes the 12 ft. x 12 ft. (3.66 m x 3.66 m) field and all
-the elements described in the official field drawings. For remote games, the playing field is a part of the Competition Area that includes the 12 ft. x 8 ft. (3.66 m x 2.44 m) field and all the elements described 
-in the official field drawings. The base field stays the same for all games but the game elements are subject to change as per :ref:`Game Manual Part 2<manuals/game_manuals/game_manuals:game manuals>`.
+-----------------------
 
+There are multiple configurations of the playing field that can be used. For traditional games, the playing field is a part of the Arena that includes the 12 ft. x 12 ft. (3.66 m x 3.66 m) field and all
+the elements described in the official field drawings. For remote games, the playing field is a part of the Arena that includes a 12 ft. x 8 ft. (3.66 m x 2.44 m) field and all the elements described 
+in the official field drawings. The base field stays the same for all games but the game elements are subject to change as per the Competition Manual.
 
-Traditional Field Setup Guide
-------------------------------------
+The Competition Manual contains an Arena section that details the playing field for that years game.
+It includes measurements for key aspects of the field and game elements and scoring elements.
+For example, the height of a basket into which a scoring element can be placed.
+The Competition Manual can be found on the
+`Game and Season Materials page <https://ftc-resources.firstinspires.org/files/ftc/game>`_ on the *FIRST* Website.
 
-This document can be found here: `Traditional Field Setup Guide <https://ftc-resources.firstinspires.org/file/ftc/game/fieldguide>`__
+The Game and Season Materials page also contains downloadable PDFs for the AprilTag images that can be printed and placed on the field.
+There is also a do it yourself (DIY) Resources section that include CAD models of the game and scoring elements and DIY field and perimeter build guides.
 
-.. only:: html
+Field Setup Guide
+-----------------
 
-   .. raw:: html
+The Field Setup Guide has the official instructions for assembling and setting up a *FIRST* Tech Challenge field.
+There are also teardown instructions that indicate how to take apart the field for storage or transport.
+Typically assembly instructions build structures, structures then have setup instructions for placing on the field.
+For example, you assemble a game element structure that can be setup on the field and the teardown
+instruction indicates how it can be removed from the field.
 
-       <iframe id="iframepdf" src="https://ftc-resources.firstinspires.org/file/ftc/game/fieldguide" width="100%" height="700"></iframe>
+A guide typically has the following sections:
 
-|
+- A list of all tools required for assembly and setup, some tools are only for assembly or for setup.
+- Lists all the game elements and scoring elements with the quantity of each.
+- Instructions for setup of the field perimeter and field tiles.
+- Step by step instructions for assembling parts and setting them on the field.
+- Most games have tape lines on the field to mark locations or areas of the game. There are also taped areas outside the field for the Alliances, and sometimes for game areas.
+- Most games have AprilTags placed around the field that can be used for robot navigation.
+- Finally, there are teardown instructions that indicate how to take the field down for storage or transport.
+
+.. note:: The Field Setup Guide has instructions for assembling an official game set as purchased from AndyMark.
+   
+   A purchased game set can be full or partial. A partial game set is less expensive and also suitable for teams who
+   want official game elements but don't have room to setup a full field.
+
+Use the following button link to download a PDF of the Field Setup Guide from the *FIRST* Website:
+
+.. button-link:: https://ftc-resources.firstinspires.org/file/ftc/game/fieldguide
+   :color: primary
+
+   Download PDF, 4.5 MB, will open in a new tab
+    

--- a/docs/source/game_specific_resources/playing_field_resources/playing_field_resources.rst
+++ b/docs/source/game_specific_resources/playing_field_resources/playing_field_resources.rst
@@ -19,19 +19,14 @@ For example, the height of a basket into which a scoring element can be placed.
 The Competition Manual can be found on the
 `Game and Season Materials page <https://ftc-resources.firstinspires.org/files/ftc/game>`_ on the *FIRST* Website.
 
-The Game and Season Materials page also contains downloadable PDFs for the AprilTag images that can be printed and placed on the field.
-There is also a do it yourself (DIY) Resources section that include CAD models of the game and scoring elements and DIY field and perimeter build guides.
-
 Field Setup Guide
 -----------------
 
 The Field Setup Guide has the official instructions for assembling and setting up a *FIRST* Tech Challenge field.
+Typically there are assembly instructions that build structures that then have setup instructions for placing on the field.
 There are also teardown instructions that indicate how to take apart the field for storage or transport.
-Typically assembly instructions build structures, structures then have setup instructions for placing on the field.
-For example, you assemble a game element structure that can be setup on the field and the teardown
-instruction indicates how it can be removed from the field.
 
-A guide typically has the following sections:
+The guide typically has the following sections:
 
 - A list of all tools required for assembly and setup, some tools are only for assembly or for setup.
 - Lists all the game elements and scoring elements with the quantity of each.
@@ -41,15 +36,17 @@ A guide typically has the following sections:
 - Most games have AprilTags placed around the field that can be used for robot navigation.
 - Finally, there are teardown instructions that indicate how to take the field down for storage or transport.
 
-.. note:: The Field Setup Guide has instructions for assembling an official game set as purchased from AndyMark.
-   
-   A purchased game set can be full or partial. A partial game set is less expensive and also suitable for teams who
-   want official game elements but don't have room to setup a full field.
-
 Use the following button link to download a PDF of the Field Setup Guide from the *FIRST* Website:
 
 .. button-link:: https://ftc-resources.firstinspires.org/file/ftc/game/fieldguide
    :color: primary
 
    Download PDF, 4.5 MB, will open in a new tab
-    
+
+.. note:: The Field Setup Guide has instructions for assembling an official game set as purchased from AndyMark.
+   
+   A purchased game set can be full or partial. A partial game set is less expensive and also suitable for teams who
+   want official game elements but don't have room to setup a full field.
+
+The `Game and Season Materials page (FIRST website) <https://ftc-resources.firstinspires.org/files/ftc/game>`_ also contains downloadable PDFs for the AprilTag images that can be printed and placed on the field.
+There is also a do it yourself (DIY) Resources section that include CAD models of the game and scoring elements and DIY field and perimeter build guides.


### PR DESCRIPTION
Replace with a PDF 'gateway' section and button link.

This is a fix to and accessibility issue: when tabbing through the current page focus is trapped in the iframe and cannot escape.

The replace the iframe with a "gateway page" which summarizes the PDF and let's the user decide if they want to take the trouble to view or download it. The link is styled as a button to ensure it is distinct from regular links. It also has text indicating the link is to a PDF,  the file size, and that the link will open in a new tab. These are all accessibility features.

Here's what this will look like:
![image](https://github.com/user-attachments/assets/391db010-b979-4a3f-a160-b74fd100a7bb)

