### PR TITLE
Add NoFollow Metadata to booklet pages

### DIFF
--- a/docs/source/booklets/advanced.rst
+++ b/docs/source/booklets/advanced.rst
@@ -1,4 +1,6 @@
 :orphan:
+.. meta::
+   :robots: noindex, nofollow
 
 .. only:: latex
 


### PR DESCRIPTION
This is to avoid users ending up on pages that are purely meant for building custom booklets. 