### PR TITLE
Upgrade Sphinx 5.0.0 -> 8.2.3

### DIFF
--- a/.github/workflows/booklets.yaml
+++ b/.github/workflows/booklets.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Python Setup
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.11
           cache: 'pip'
       
       - name: Python Install Dependencies

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Python Setup
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.11
           cache: 'pip'
 
       - name: Python Install Dependencies
@@ -54,7 +54,7 @@ jobs:
       - name: Python Setup
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.11
           cache: 'pip'
 
       - name: Python Install Dependencies
@@ -92,7 +92,7 @@ jobs:
       - name: Python Setup
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.11
           cache: 'pip'
 
       - name: Python Install Dependencies
@@ -161,7 +161,7 @@ jobs:
       - name: Python Setup
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.11
 
       - name: Python Install Dependencies
         run: pip install -r docs/requirements.txt
@@ -181,7 +181,7 @@ jobs:
       - name: Python Setup
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.11
           cache: 'pip'
 
       - name: Python Install Dependencies

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,7 +21,7 @@ formats:
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.9"
+    python: "3.11"
     
 python:
   install:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,9 @@
-Sphinx==5.0.0
+Sphinx==8.2.3
 sphinx-autobuild==2024.2.4
 make==0.1.6.post2
 git+https://github.com/FIRST-Tech-Challenge/ftcdocs-helper@main#subdirectory=sphinx_rtd_dark_mode_v2
 git+https://github.com/FIRST-Tech-Challenge/ftcdocs-helper@main#subdirectory=javasphinx
-sphinx_design==0.2.0
+sphinx_design==0.7.0
 git+https://github.com/FIRST-Tech-Challenge/ftcdocs-helper@main#subdirectory=googleanalytics
 git+https://github.com/FIRST-Tech-Challenge/ftcdocs-helper@main#subdirectory=cookiebanner
 sphinx-sitemap==2.3.0


### PR DESCRIPTION
## Summary
- Sphinx 5.0.0's `gettext` builder crashes on some message catalogs (`TypeError: '<' not supported between instances of 'int' and 'NoneType'` when sorting message positions). This breaks `ftcdocs-translations`' POT extraction pipeline, which has been disabled in CI for ~3 years for unrelated reasons and is being revived (FIRST-Tech-Challenge/ftcdocs-translations#4). Sphinx 8.2.3 fixes this bug.
- Sphinx 8.2.3 requires Python >=3.11, so bumped `.readthedocs.yaml` and all `python-version` pins in `pull-request.yaml`/`booklets.yaml` accordingly.
- Bumped `sphinx_design` 0.2.0 -> 0.7.0, since 0.2.0 hard-pins `sphinx<6`.
- Depends on FIRST-Tech-Challenge/ftcdocs-helper#7 landing first -- the `linkcheckdiff` extension (pulled via `git+...@main`) has a bug where `add_config_value` passes a list positionally as `rebuild`, which Sphinx 8 rejects since `rebuild` must be hashable. Without that fix, any HTML build crashes immediately.

Verified locally: HTML build (incl. under `-W --keep-going -n`), gettext extraction, and booklets/latex generation all succeed with this dependency set once the linkcheckdiff fix is applied.