### PR TITLE
Replace manual dependency setup with a Nix flake

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,17 @@
 FROM python:3.9.18-bullseye
 WORKDIR /app
 COPY . .
-RUN apt-get update && apt-get install -y texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra latexmk texlive-lang-greek texlive-luatex texlive-xetex texlive-fonts-extra dvipng librsvg2-bin git fonts-roboto
-RUN pip install -r docs/requirements.txt
+
+# Dependencies for building the docs (Python, Sphinx, and the LaTeX/PDF
+# toolchain) are now provided by the Nix flake at the repository root
+# instead of apt-get/pip here -- see flake.nix. Install Nix (single-user,
+# no daemon, which is the supported mode inside a container) and enable
+# flakes so `nix develop` works out of the box.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl xz-utils ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -L https://nixos.org/nix/install | sh -s -- --no-daemon \
+    && mkdir -p /etc/nix \
+    && echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf
+
+ENV PATH="/root/.nix-profile/bin:${PATH}"

--- a/.github/workflows/booklets.yaml
+++ b/.github/workflows/booklets.yaml
@@ -14,28 +14,19 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - name: Checkout Repository  
+      - name: Checkout Repository
         uses: actions/checkout@v3
 
-      - name: Refresh Packages
-        run: sudo apt-fast -y update
-      
-      - name: Install Dependencies
-        run: xargs -a dependencies sudo apt-fast install -y
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v22
 
-      - name: Python Setup
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.11
-          cache: 'pip'
-      
-      - name: Python Install Dependencies
-        run: pip install -r docs/requirements.txt
+      - name: Set up Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v14
 
       - name: Build Booklets
         env:
           SPHINXOPTS: "-D html_context.commit=${{ github.sha }} -D version=latest -A display_github=true -A github_user=${{ github.repository_owner }} -A github_repo=${{ github.event.repository.name }} -A github_version=${{ github.ref_name }} -A conf_py_path=/docs/source/"
-        run: make -C docs/ booklets
+        run: nix develop -c make -C docs/ booklets
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/link-check.yaml
+++ b/.github/workflows/link-check.yaml
@@ -9,20 +9,17 @@ jobs:
   link-check:
     runs-on: ubuntu-22.04
     steps:
-      - name: Checkout Repository  
+      - name: Checkout Repository
         uses: actions/checkout@v3
 
-      - name: Python Setup
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.9
-          cache: 'pip'
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v22
 
-      - name: Python Install Dependencies
-        run: pip install -r docs/requirements.txt
+      - name: Set up Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v14
 
       - name: link-check
-        run: make -C docs/ linkcheckdiff SPHINXOPTS="--keep-going"
+        run: nix develop -c make -C docs/ linkcheckdiff SPHINXOPTS="--keep-going"
 
       - name: Arhive Log
         if: ${{ failure() }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -7,28 +7,19 @@ jobs:
   build-pdf:
     runs-on: ubuntu-22.04
     steps:
-      - name: Checkout Repository  
+      - name: Checkout Repository
         uses: actions/checkout@v3
-        
-      - name: Refresh Packages
-        run: sudo apt-fast -y update
-        
-      - name: Install Dependencies
-        run: xargs -a dependencies sudo apt-fast install -y
 
-      - name: Python Setup
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.11
-          cache: 'pip'
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v22
 
-      - name: Python Install Dependencies
-        run: pip install -r docs/requirements.txt
-        
+      - name: Set up Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v14
+
       - name: Build PDF
         env:
           SPHINXOPTS: "-D html_context.commit=${{ github.sha }} -D version=latest -A display_github=true -A github_user=${{ github.repository_owner }} -A github_repo=${{ github.event.repository.name }} -A github_version=${{ github.ref_name }} -A conf_py_path=/docs/source/"
-        run: make -C docs/ latexpdf
+        run: nix develop -c make -C docs/ latexpdf
         
       - name: Archive PDF
         env:
@@ -45,25 +36,19 @@ jobs:
   build-html:
     runs-on: ubuntu-22.04
     steps:
-      - name: Checkout Repository  
+      - name: Checkout Repository
         uses: actions/checkout@v3
-        
-      - name: Refresh Packages
-        run: sudo apt-fast -y update
 
-      - name: Python Setup
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.11
-          cache: 'pip'
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v22
 
-      - name: Python Install Dependencies
-        run: pip install -r docs/requirements.txt
-        
+      - name: Set up Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v14
+
       - name: Build Site
         env:
           SPHINXOPTS: "-W --keep-going -n -D html_context.commit=${{ github.sha }} -D version=latest -A display_github=true -A github_user=${{ github.repository_owner }} -A github_repo=${{ github.event.repository.name }} -A github_version=${{ github.ref_name }} -A conf_py_path=/docs/source/"
-        run: make -C docs/ html
+        run: nix develop -c make -C docs/ html
           
       - name: Archive Site
         uses: actions/upload-artifact@v4
@@ -86,17 +71,14 @@ jobs:
   link-check:
     runs-on: ubuntu-22.04
     steps:
-      - name: Checkout Repository  
+      - name: Checkout Repository
         uses: actions/checkout@v3
 
-      - name: Python Setup
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.11
-          cache: 'pip'
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v22
 
-      - name: Python Install Dependencies
-        run: pip install -r docs/requirements.txt
+      - name: Set up Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v14
 
       - name: Install additional dependencies
         run: |
@@ -142,7 +124,7 @@ jobs:
 
       - name: link-check
         run: |
-          make -C docs/ linkcheckdiff SPHINXOPTS="--keep-going"
+          nix develop -c make -C docs/ linkcheckdiff SPHINXOPTS="--keep-going"
 
       - name: Archive Log
         if: always()
@@ -155,37 +137,32 @@ jobs:
   image-check:
     runs-on: ubuntu-22.04
     steps:
-      - name: Checkout Repository  
+      - name: Checkout Repository
         uses: actions/checkout@v3
 
-      - name: Python Setup
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.11
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v22
 
-      - name: Python Install Dependencies
-        run: pip install -r docs/requirements.txt
+      - name: Set up Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v14
 
       - name: image-check
-        run: make -C docs/ imagecheck
+        run: nix develop -c make -C docs/ imagecheck
 
   check-redirect:
     runs-on: ubuntu-22.04
     steps:
-      - name: Checkout Repository  
+      - name: Checkout Repository
         uses: actions/checkout@v3
 
       - name: Fetch origin/main
         run: git fetch origin main --depth=1
 
-      - name: Python Setup
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.11
-          cache: 'pip'
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v22
 
-      - name: Python Install Dependencies
-        run: pip install -r docs/requirements.txt
+      - name: Set up Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v14
 
       - name: check-redirect
-        run: make -C docs/ rediraffecheckdiff
+        run: nix develop -c make -C docs/ rediraffecheckdiff

--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,10 @@ cython_debug/
 
 # End of https://www.toptal.com/developers/gitignore/api/python,jupyternotebooks
 
+# Nix build outputs
+result
+result-*
+
 # PyCharm project settings
 .idea/
 .idea/workspace.xml

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,12 +3,14 @@
         {
             "type": "shell",
             "label": "make-setup",
-            "command": "make",
+            "command": "nix",
             "options": {
-                "cwd": "${workspaceFolder}/docs"
+                "cwd": "${workspaceFolder}"
             },
             "args": [
-                "setup"
+                "develop",
+                "--command",
+                "true"
             ],
             "group": {
                 "kind": "build",
@@ -18,11 +20,16 @@
         {
             "type": "shell",
             "label": "make-html",
-            "command": "make",
+            "command": "nix",
             "options": {
-                "cwd": "${workspaceFolder}/docs"
+                "cwd": "${workspaceFolder}"
             },
             "args": [
+                "develop",
+                "--command",
+                "make",
+                "-C",
+                "docs",
                 "html"
             ],
             "group": {
@@ -33,11 +40,16 @@
         {
             "type": "shell",
             "label": "make-latexpdf",
-            "command": "make",
+            "command": "nix",
             "options": {
-                "cwd": "${workspaceFolder}/docs"
+                "cwd": "${workspaceFolder}"
             },
             "args": [
+                "develop",
+                "--command",
+                "make",
+                "-C",
+                "docs",
                 "latexpdf"
             ],
             "group": {
@@ -48,11 +60,16 @@
         {
             "type": "shell",
             "label": "make-autobuild",
-            "command": "make",
+            "command": "nix",
             "options": {
-                "cwd": "${workspaceFolder}/docs"
+                "cwd": "${workspaceFolder}"
             },
             "args": [
+                "develop",
+                "--command",
+                "make",
+                "-C",
+                "docs",
                 "autobuild"
             ],
             "problemMatcher": [],
@@ -64,11 +81,16 @@
         {
             "type": "shell",
             "label": "make-clean",
-            "command": "make",
+            "command": "nix",
             "options": {
-                "cwd": "${workspaceFolder}/docs"
+                "cwd": "${workspaceFolder}"
             },
             "args": [
+                "develop",
+                "--command",
+                "make",
+                "-C",
+                "docs",
                 "clean"
             ],
             "problemMatcher": []

--- a/README.md
+++ b/README.md
@@ -11,3 +11,16 @@ The website is available at https://ftc-docs.firstinspires.org
 
 We are always looking for help improving FTC Docs. For more infomration on contributing 
 consult the [contributing section](https://ftc-docs.firstinspires.org/contrib/index.html) in FTC Docs.
+
+# Building Locally
+
+This repository provides a [Nix](https://nixos.org) flake with everything needed to build the site
+(Python, Sphinx, and the LaTeX toolchain used for PDF booklets). With Nix installed, run:
+
+```
+nix develop
+make -C docs html
+```
+
+See the [environment setup guide](https://ftc-docs.firstinspires.org/contrib/tutorials/setup/setup.html)
+for more detail.

--- a/dependencies
+++ b/dependencies
@@ -1,3 +1,0 @@
-texlive-xetex
-latexmk
-fonts-roboto

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -24,7 +24,11 @@ help:
 .PHONY: help Makefile
 
 setup:
-	python -m pip install -r requirements.txt
+	@echo "Dependencies for local development are now managed by the Nix flake"
+	@echo "at the repository root. Run 'nix develop' from the repository root"
+	@echo "(or use direnv) to enter a shell with Python, Sphinx, and the LaTeX"
+	@echo "toolchain already installed."
+	@echo "(requirements.txt is kept only for the Read the Docs build.)"
 
 autobuild:
 	@$(AUTOBUILD) $(SOURCEDIR) $(HTMLBUILDDIR) --port=7350

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,10 @@
+# NOTE: This file is kept only because Read the Docs' build environment
+# installs Python dependencies via `python.install: requirements:` in
+# .readthedocs.yaml and does not support building from a Nix flake.
+# Local development and CI now use the Nix flake at the repository root
+# (see flake.nix / `nix develop`) as the source of truth for dependencies;
+# keep this file in sync with flake.nix's ftcdocsPython package list when
+# bumping versions.
 Sphinx==8.2.3
 sphinx-autobuild==2024.2.4
 make==0.1.6.post2

--- a/docs/source/contrib/tutorials/setup/setup.rst
+++ b/docs/source/contrib/tutorials/setup/setup.rst
@@ -7,7 +7,7 @@ Setting Up Your Development Environment
    Only complete these steps if you have chosen to develop the site locally. 
    If you are using **GitHub Codespaces** you should skip this section.
 
-FTC Docs uses a `Nix <https://nixos.org>`_ flake (``flake.nix`` at the root of the repository) to provide every
+FTC Docs uses a `Nix <https://nixos.org>`__ flake (``flake.nix`` at the root of the repository) to provide every
 dependency needed to build the site -- Python, Sphinx, and the LaTeX toolchain used for PDF booklets -- in one
 reproducible environment. You no longer need to install Python, Pip, or a LaTeX distribution yourself.
 
@@ -26,13 +26,13 @@ Steps
       Nix (and the LaTeX/PDF build) requires Linux or macOS, so on Windows you'll need `WSL2 <https://learn.microsoft.com/en-us/windows/wsl/install>`_.
 
       1. Install WSL2 and a Linux distribution (e.g. Ubuntu) by running ``wsl --install`` in an administrator PowerShell prompt.
-      2. Open a WSL terminal and install `Nix <https://nixos.org/download>`_: ``sh <(curl -L https://nixos.org/nix/install) --daemon``
+      2. Open a WSL terminal and install `Nix <https://nixos.org/download>`__: ``sh <(curl -L https://nixos.org/nix/install) --daemon``
       3. Install Git (usually already available in WSL, otherwise ``sudo apt install git``).
       4. Install the latest version of `VS Code <https://code.visualstudio.com/download>`_, along with the `WSL extension <https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl>`_, and open your cloned repository from within WSL.
 
    .. tab-item:: Linux/Mac
 
-      1. Install `Nix <https://nixos.org/download>`_: ``sh <(curl -L https://nixos.org/nix/install) --daemon``
+      1. Install `Nix <https://nixos.org/download>`__: ``sh <(curl -L https://nixos.org/nix/install) --daemon``
       2. Install Git from the `Git website <https://git-scm.com/downloads>`_.
       3. Install the lastest version of `VS Code  <https://code.visualstudio.com/download>`_.
 

--- a/docs/source/contrib/tutorials/setup/setup.rst
+++ b/docs/source/contrib/tutorials/setup/setup.rst
@@ -7,11 +7,11 @@ Setting Up Your Development Environment
    Only complete these steps if you have chosen to develop the site locally. 
    If you are using **GitHub Codespaces** you should skip this section.
 
-FTC Docs has a few dependencies that you'll need to install before you can start developing. 
-Full build features are only available on Linux. This will only effect those who 
-are looking to build PDFs locally.
+FTC Docs uses a `Nix <https://nixos.org>`_ flake (``flake.nix`` at the root of the repository) to provide every
+dependency needed to build the site -- Python, Sphinx, and the LaTeX toolchain used for PDF booklets -- in one
+reproducible environment. You no longer need to install Python, Pip, or a LaTeX distribution yourself.
 
-Remember, this step should **ony be done for Local Development**. If you are using **GitHub Codespaces** 
+Remember, this step should **only be done for Local Development**. If you are using **GitHub Codespaces**
 you should skip this step. Also note that these steps should only be done **once**.
 
 Steps
@@ -23,20 +23,18 @@ Steps
 .. tab-set::
    .. tab-item:: Windows
 
-      1. Install `Chocolatey <https://docs.chocolatey.org/en-us/choco/setup>`_.
-      2. Install Python 3.9-3.12 from the `Python website <https://www.python.org/downloads/windows/>`_. **Make sure to check the box that says "Add Python to PATH".**
-      3. Install Pip. ``python -m ensurepip``
-      4. Install Git. ``choco install git``
-      5. Install Make. ``choco install make``
-      6. Install the lastest version of VS Code. ``choco install vscode``
-   
+      Nix (and the LaTeX/PDF build) requires Linux or macOS, so on Windows you'll need `WSL2 <https://learn.microsoft.com/en-us/windows/wsl/install>`_.
+
+      1. Install WSL2 and a Linux distribution (e.g. Ubuntu) by running ``wsl --install`` in an administrator PowerShell prompt.
+      2. Open a WSL terminal and install `Nix <https://nixos.org/download>`_: ``sh <(curl -L https://nixos.org/nix/install) --daemon``
+      3. Install Git (usually already available in WSL, otherwise ``sudo apt install git``).
+      4. Install the latest version of `VS Code <https://code.visualstudio.com/download>`_, along with the `WSL extension <https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl>`_, and open your cloned repository from within WSL.
+
    .. tab-item:: Linux/Mac
 
-      1. Install Python 3.9-3.12. You can download it from the Python website: `macOS <https://www.python.org/downloads/macos/>`_, `Linux <https://www.python.org/downloads/source/>`_.
-      2. Install the latest version of `Pip <https://pip.pypa.io/en/stable/installation/>`_.
-      3. Install Git from the `Git website <https://git-scm.com/downloads>`_.
-      4. Install `Make <https://www.gnu.org/software/make/>`_ .
-      5. Install the lastest version of `VS Code  <https://code.visualstudio.com/download>`_.
+      1. Install `Nix <https://nixos.org/download>`_: ``sh <(curl -L https://nixos.org/nix/install) --daemon``
+      2. Install Git from the `Git website <https://git-scm.com/downloads>`_.
+      3. Install the lastest version of `VS Code  <https://code.visualstudio.com/download>`_.
 
 
 1. Open VS Code

--- a/docs/source/usage.txt
+++ b/docs/source/usage.txt
@@ -5,11 +5,15 @@ Usage
 
 Installation
 ------------
-This project has a number of requirements to install on a clean system:
+This project provides a `Nix <https://nixos.org>`_ flake with everything needed to build the docs.
+Install Nix, then from the repository root run:
 
 .. code-block:: console
 
-    pip install -r requirements.txt
+    nix develop
+
+This drops you into a shell with Python, Sphinx, and the LaTeX toolchain used for PDF booklets already
+installed. See :doc:`/contrib/tutorials/setup/setup` for more detail.
 
 
 Generating Documentation Locally

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1767313136,
+        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,282 @@
+{
+  description = "Reproducible build environment for FTC Docs (Sphinx + LaTeX/PDF booklets)";
+
+  inputs = {
+    # Pinned to nixos-25.05 because it is the newest release branch that still ships
+    # Sphinx 8.2.3 for Python 3.11 (nixpkgs-unstable has since moved to Sphinx 9.x,
+    # which drops Python 3.11 support). Bump this once the repo moves off Python 3.11.
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        python = pkgs.python311;
+        py = python.pkgs;
+
+        # ----------------------------------------------------------------------
+        # FIRST-Tech-Challenge/ftcdocs-helper
+        #
+        # Several Sphinx extensions used by this site (dark mode theme, the
+        # Java API doc builder, the cookie banner, Google Analytics glue, and
+        # the linkcheck-diff builder) live in this companion repo and were
+        # previously installed with
+        #   pip install git+https://github.com/.../ftcdocs-helper@main#subdirectory=<name>
+        # i.e. always tracking the tip of `main`. For a reproducible flake we
+        # pin to a specific commit instead. Bump `ftcdocsHelperRev` (and the
+        # hash, which `nix build` will report on mismatch) when a new helper
+        # release is needed.
+        # ----------------------------------------------------------------------
+        ftcdocsHelperRev = "5fa0c07f1a6670bc4df84d072ba955380d09f280";
+        ftcdocsHelperSrc = pkgs.fetchFromGitHub {
+          owner = "FIRST-Tech-Challenge";
+          repo = "ftcdocs-helper";
+          rev = ftcdocsHelperRev;
+          hash = "sha256-uZpCb61P1mBt+/CN7uTgQg6Syk9tmKBTxjZP95YtYRI=";
+        };
+
+        # ----------------------------------------------------------------------
+        # Plain-PyPI packages pinned to the exact versions previously listed in
+        # docs/requirements.txt but not (yet) packaged in nixpkgs/25.05.
+        # ----------------------------------------------------------------------
+        javalang = py.buildPythonPackage {
+          pname = "javalang";
+          version = "0.13.0";
+          format = "setuptools";
+          src = pkgs.fetchPypi {
+            pname = "javalang";
+            version = "0.13.0";
+            hash = "sha256-FoGlpIClgRbUKn7t/RMqviXmwP/lUoaNWBrYTmqjQkw=";
+          };
+          propagatedBuildInputs = [ py.six ];
+          doCheck = false;
+        };
+
+        pythonGitInfo = py.buildPythonPackage {
+          pname = "python-git-info";
+          version = "0.8.3";
+          format = "setuptools";
+          src = pkgs.fetchPypi {
+            pname = "python-git-info";
+            version = "0.8.3";
+            hash = "sha256-wIonZKFtoCnk25CauENq5IT4hGQF+Dsbz9QV/l46sw0=";
+          };
+          doCheck = false;
+        };
+
+        sphinxDesign = py.buildPythonPackage {
+          pname = "sphinx_design";
+          version = "0.7.0";
+          format = "pyproject";
+          src = pkgs.fetchPypi {
+            pname = "sphinx_design";
+            version = "0.7.0";
+            hash = "sha256-0qP1sZwkuRattS+XxfAO+rQAnKM3gSABEJCEp0Dsm3o=";
+          };
+          nativeBuildInputs = [ py.flit-core ];
+          propagatedBuildInputs = [ py.sphinx ];
+          doCheck = false;
+        };
+
+        sphinxAutobuild = py.buildPythonPackage {
+          pname = "sphinx_autobuild";
+          version = "2024.2.4";
+          format = "pyproject";
+          src = pkgs.fetchPypi {
+            pname = "sphinx_autobuild";
+            version = "2024.2.4";
+            hash = "sha256-y50hIaF21i1FRxYkhyr8X613Va1mJzir5ADs9KeVQwM=";
+          };
+          nativeBuildInputs = [ py.flit-core ];
+          propagatedBuildInputs = [
+            py.sphinx
+            py.livereload
+            py.colorama
+          ];
+          doCheck = false;
+        };
+
+        sphinxSitemap = py.buildPythonPackage {
+          pname = "sphinx-sitemap";
+          version = "2.3.0";
+          format = "setuptools";
+          src = pkgs.fetchPypi {
+            pname = "sphinx-sitemap";
+            version = "2.3.0";
+            hash = "sha256-eye12fbr91WX2n1Ixk3LknH6JpklZz2QDuJ9ayxISRU=";
+          };
+          propagatedBuildInputs = [ py.sphinx ];
+          doCheck = false;
+        };
+
+        sphinxcontribMermaid = py.buildPythonPackage {
+          pname = "sphinxcontrib-mermaid";
+          version = "0.9.2";
+          format = "setuptools";
+          src = pkgs.fetchPypi {
+            pname = "sphinxcontrib-mermaid";
+            version = "0.9.2";
+            hash = "sha256-JS7xPdIxZLKPFtiwIFzxhLnY4rcUowInTZ9Z63COd68=";
+          };
+          propagatedBuildInputs = [ py.sphinx ];
+          doCheck = false;
+        };
+
+        sphinxHoverxref = py.buildPythonPackage {
+          pname = "sphinx-hoverxref";
+          version = "1.3.0";
+          format = "pyproject";
+          src = pkgs.fetchPypi {
+            pname = "sphinx-hoverxref";
+            version = "1.3.0";
+            hash = "sha256-5RfatMuBhtpY14xTeBRZ7hEW7JyEE1gMfcQ+EkxfMXc=";
+          };
+          nativeBuildInputs = [ py.flit-core ];
+          propagatedBuildInputs = [
+            py.sphinx
+            py.sphinxcontrib-jquery
+          ];
+          doCheck = false;
+        };
+
+        sphinxNotfoundPage = py.buildPythonPackage {
+          pname = "sphinx-notfound-page";
+          version = "1.1.0";
+          format = "pyproject";
+          src = pkgs.fetchPypi {
+            pname = "sphinx_notfound_page";
+            version = "1.1.0";
+            hash = "sha256-kT4XVDcLs9sgHZMA1FiouLX7IukkaoFmQ6gZqeorgGc=";
+          };
+          nativeBuildInputs = [ py.flit-core ];
+          propagatedBuildInputs = [ py.sphinx ];
+          doCheck = false;
+        };
+
+        # ----------------------------------------------------------------------
+        # ftcdocs-helper subpackages (see comment above ftcdocsHelperSrc).
+        # ----------------------------------------------------------------------
+        javasphinx = py.buildPythonPackage {
+          pname = "javasphinx";
+          version = "0.9.15";
+          format = "setuptools";
+          src = "${ftcdocsHelperSrc}/javasphinx";
+          propagatedBuildInputs = [
+            javalang
+            py.lxml
+            py.beautifulsoup4
+            py.future
+            py.docutils
+            py.sphinx
+          ];
+          doCheck = false;
+        };
+
+        cookiebanner = py.buildPythonPackage {
+          pname = "sphinxcontrib-cookiebanner";
+          version = "0.1";
+          format = "setuptools";
+          src = "${ftcdocsHelperSrc}/cookiebanner";
+          propagatedBuildInputs = [ py.sphinx ];
+          doCheck = false;
+        };
+
+        googleanalytics = py.buildPythonPackage {
+          pname = "sphinxcontrib-googleanalytics";
+          version = "0.2";
+          format = "setuptools";
+          src = "${ftcdocsHelperSrc}/googleanalytics";
+          propagatedBuildInputs = [ py.sphinx ];
+          doCheck = false;
+        };
+
+        sphinxRtdDarkMode = py.buildPythonPackage {
+          pname = "sphinx_rtd_dark_mode";
+          version = "1.4.0";
+          format = "setuptools";
+          src = "${ftcdocsHelperSrc}/sphinx_rtd_dark_mode_v2";
+          propagatedBuildInputs = [ py.sphinx-rtd-theme ];
+          doCheck = false;
+        };
+
+        linkcheckdiff = py.buildPythonPackage {
+          pname = "ftcdocs-linkcheckdiff";
+          version = "0.1.0";
+          format = "pyproject";
+          src = "${ftcdocsHelperSrc}/linkcheckdiff";
+          nativeBuildInputs = [ py.setuptools ];
+          propagatedBuildInputs = [ py.sphinx ];
+          doCheck = false;
+        };
+
+        # ----------------------------------------------------------------------
+        # The Python environment Sphinx runs in: Sphinx itself (from nixpkgs,
+        # pinned to 8.2.3 via the nixos-25.05 input above) plus every extension
+        # docs/source/conf.py loads, matching docs/requirements.txt 1:1. The
+        # only requirements.txt entry intentionally dropped is the `make` PyPI
+        # package -- that was a Windows-only shim so `make` works without
+        # installing GNU Make separately; this flake provides real GNU Make
+        # via pkgs.gnumake instead.
+        # ----------------------------------------------------------------------
+        ftcdocsPython = python.withPackages (
+          ps: with ps; [
+            sphinx
+            sphinxAutobuild
+            javasphinx
+            sphinxRtdDarkMode
+            sphinxDesign
+            googleanalytics
+            cookiebanner
+            sphinxSitemap
+            pythonGitInfo
+            sphinxcontribMermaid
+            sphinxHoverxref
+            sphinxext-rediraffe
+            sphinxNotfoundPage
+            linkcheckdiff
+          ]
+        );
+
+        # OS-level packages needed for the LaTeX/PDF "booklets" build. This
+        # replaces the top-level `dependencies` file (texlive-xetex, latexmk,
+        # fonts-roboto). We use the full TeX Live scheme rather than hand-picking
+        # individual LaTeX packages: docs/source/conf.py's latex_elements preamble
+        # pulls in a fair number of packages (fancyhdr, titlesec, datetime2,
+        # eso-pic, ...) and a full scheme is the simplest way to guarantee the
+        # xelatex build keeps working as that preamble evolves, at the cost of a
+        # larger closure/first download.
+        texliveEnv = pkgs.texlive.combine { inherit (pkgs.texlive) scheme-full; };
+
+        docsPackages = [
+          ftcdocsPython
+          pkgs.gnumake
+          pkgs.git
+          texliveEnv
+          pkgs.roboto
+        ];
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages = docsPackages;
+          shellHook = ''
+            echo "FTC Docs dev shell ready."
+            echo "  make -C docs html       # build the HTML site"
+            echo "  make -C docs autobuild  # live-reloading local server"
+            echo "  make -C docs booklets   # build the PDF booklets (needs LaTeX)"
+          '';
+        };
+
+        # `nix build` / `nix profile install` target with the same tool set as
+        # the devShell, for use in CI and container images without needing
+        # `nix develop`.
+        packages.default = pkgs.buildEnv {
+          name = "ftcdocs-env";
+          paths = docsPackages;
+        };
+      }
+    );
+}


### PR DESCRIPTION
## Summary

Replaces the hand-maintained, duplicated dependency lists (`docs/requirements.txt` for pip, the top-level `dependencies` file for apt, plus ad-hoc TeX Live installs in the devcontainer) with a single [Nix](https://nixos.org) flake (`flake.nix` / `flake.lock`) that provides one reproducible `devShell`:

- Python 3.11 + Sphinx 8.2.3 + every Sphinx extension currently listed in `docs/requirements.txt` (including the `ftcdocs-helper` subpackages, pinned to a specific commit instead of always tracking `@main`).
- A full TeX Live toolchain for the `latexpdf`/`booklets` build, including `titling`, `fancyhdr`, `color`, `eso-pic`, `titlesec`, `datetime2`, and `geometry` — the packages `docs/source/conf.py`'s `latex_elements` preamble needs (this also avoids reproducing the `titling.sty not found` issue another in-flight PR is fixing on the apt side).

**Why:** the same set of dependencies was previously declared in four different places (`docs/requirements.txt`, `dependencies`, five GitHub Actions workflows' `apt-fast`/`pip` steps, and `.devcontainer/Dockerfile`) that could silently drift out of sync. One flake is now the single source of truth for local dev and CI.

### What changed

- **Added** `flake.nix` / `flake.lock` at the repo root.
- **`.github/workflows/*.yaml`**: `booklets.yaml`, `pull-request.yaml`, and `link-check.yaml` now install Nix (`DeterminateSystems/nix-installer-action`) and run build steps via `nix develop -c ...` instead of `apt-fast install` + `pip install -r docs/requirements.txt`.
- **`.devcontainer/Dockerfile`**: installs Nix instead of apt/pip-installing the toolchain directly.
- **`.vscode/tasks.json`**: the `make-*` tasks now run through `nix develop --command ...`.
- **`docs/Makefile`**: `setup` target now points contributors at `nix develop` instead of `pip install -r requirements.txt`.
- **Removed** the top-level `dependencies` file (no longer referenced anywhere).
- **`README.md`**, **`docs/source/usage.txt`**, **`docs/source/contrib/tutorials/setup/setup.rst`**: updated local-dev instructions to install Nix and run `nix develop` instead of installing Python/pip/choco packages by hand.

### Design decision: Read the Docs

RTD's own build environment installs Python dependencies via `python.install: requirements:` in `.readthedocs.yaml` and has no supported way to build from a Nix flake. Rather than risk breaking the live production docs build by trying to shoehorn Nix into RTD's sandboxed builder, **`docs/requirements.txt` is intentionally kept** (annotated with a comment explaining why) purely for RTD's use; `.readthedocs.yaml` is untouched. Local dev and all GitHub Actions CI now use the flake exclusively. This does mean `requirements.txt` needs to be kept in sync with `flake.nix`'s package list by hand going forward — noting this tradeoff rather than blocking on a full RTD migration.

## Test plan

- [x] `nix flake check` passes (evaluates both `devShells` and `packages` outputs).
- [x] `nix develop -c make -C docs html` — verified locally, builds the full HTML site successfully.
- [x] `nix develop -c make -C docs booklets` — verified locally, produces all 11 PDF booklets in `docs/build/booklets`, confirming the flake's TeX Live closure includes `titling.sty` and the other preamble packages.
- [x] Confirmed `nix develop -c python3 -c "import ..."` succeeds for every Sphinx extension `conf.py` loads.
- [ ] CI (this PR): verify `pull-request.yaml`'s `build-html`, `build-pdf`, `link-check`, `image-check`, and `check-redirect` jobs pass with the new Nix-based steps.
- [ ] CI (on merge to `main`): verify `booklets.yaml` still uploads booklets to S3 successfully.
- [ ] Not verified: an end-to-end GitHub Codespaces / devcontainer build (no Docker daemon available in the sandbox this PR was prepared in) — the Dockerfile change is structurally sound (Nix single-user install + flakes enabled) but should get a real Codespaces smoke test.