### PR TITLE
Add texlive-latex-extra to fix make latexpdf missing packages

### DIFF
--- a/dependencies
+++ b/dependencies
@@ -1,3 +1,4 @@
 texlive-xetex
+texlive-latex-extra
 latexmk
 fonts-roboto


### PR DESCRIPTION
## Summary

- `make -C docs latexpdf` (and `make -C docs booklets`, which does the same LaTeX build with `BOOKLETS_BUILD=true`) fails with `! LaTeX Error: File 'titling.sty' not found.` on a plain/minimal TeX Live install, because `docs/source/conf.py`'s `latex_elements['passoptionstopackages']` does `\usepackage{titling}`. Once `titling.sty` is available, the same class of error recurs for several more packages used either directly in `conf.py`'s LaTeX preamble or required internally by Sphinx's own generated `sphinx.sty`: `datetime2.sty` (+ its dependency `tracklang.sty`), `fncychap.sty`, `wrapfig.sty`, `capt-of.sty`.
- On Debian/Ubuntu, all of these files ship in the `texlive-latex-extra` apt package. The root `dependencies` file (installed in CI via `xargs -a dependencies sudo apt-fast install -y` in both `pull-request.yaml` and `booklets.yaml`) does not list `texlive-latex-extra` directly — it only lists `texlive-xetex`, `latexmk`, and `fonts-roboto`.
- CI currently happens to still work today because `texlive-xetex` on Ubuntu 22.04 has a hard `Depends` on `texlive-latex-extra`, so it gets pulled in transitively (confirmed: the `build-pdf` job in the most recent `pull-request.yaml` run passed). That's fragile/implicit though — it relies on an indirect dependency of a dependency rather than something the repo declares, and it's exactly why this doesn't reproduce for everyone: on a non-Debian TeX Live install (e.g. MacTeX/TeX Live's smaller "basic" scheme on macOS, which is what I hit locally) there's no such transitive pull, so `titling.sty` (and the others above) are simply missing. Notably, `.devcontainer/Dockerfile` (used for Codespaces) already installs `texlive-latex-extra` explicitly, so this PR just brings the CI apt-package list in line with what the devcontainer already does, instead of relying on an undocumented side effect of `texlive-xetex`'s current dependency graph.

## Fix

Add `texlive-latex-extra` to the root `dependencies` file, alongside the already-listed `texlive-xetex`. This is additive only — it doesn't change or remove any existing entries in `dependencies`, `docs/Makefile`, `booklets.yaml`, or `pull-request.yaml`.

I did not change `.readthedocs.yaml`: Read the Docs builds the `pdf` format itself (not via `docs/Makefile`/`dependencies`) using its own build image, which already ships a much fuller TeX Live than the `dependencies`-driven GitHub Actions runners, so this isn't expected to be affected.

## Test plan

- Reproduced the reported failure locally on macOS (TeX Live 2025 "basic" scheme): `make -C docs latexpdf` failed with `titling.sty not found`. After installing just `titling`, the next run failed on `fncychap.sty not found`, then `wrapfig.sty`, then `capt-of.sty` — confirming that the whole `conf.py` LaTeX preamble *and* Sphinx's own generated `sphinx.sty` are at risk on a minimal install, not just the one package named in the original error.
- Installed the local equivalent of `texlive-latex-extra` (`tlmgr install collection-latexextra`, from a pinned TeX Live 2025 archive mirror since the default CTAN mirrors have since rolled over to TeX Live 2026) and confirmed all the previously-missing files now resolve: `kpsewhich titling.sty datetime2.sty tracklang.sty fncychap.sty wrapfig.sty capt-of.sty` all succeed. Also compiled a minimal standalone `.tex` file that `\usepackage`s all six of those packages together — it compiled cleanly to a 1-page PDF with `pdflatex`.
- I started a full `make -C docs latexpdf` run against the real doc tree after installing `collection-latexextra`, and watched it progress cleanly through 200+ pages (well past every package that previously failed, no new "file not found" errors) before I stopped it to stay within this sandbox's time budget — I did not let it run to completion, so I can't quote a final page count for `ftcdocs.pdf` from this environment. The targeted package-resolution checks above are what I'm basing "fixed" on.
- Ran `make -C docs imagecheck` to confirm the change doesn't affect that target (it's pure Python and doesn't touch LaTeX).
- Did not have a Debian/Ubuntu container available in this sandbox to re-run the actual `apt-fast install -y texlive-latex-extra` command. Instead, confirmed via `packages.ubuntu.com`'s file listings for Ubuntu 22.04 (jammy) that `texlive-latex-extra` contains `titling.sty`, `datetime2.sty`, `titlesec.sty`, `fncychap.sty`, and `wrapfig.sty`/`capt-of.sty`, and that its `Recommends` on `texlive-plain-generic` covers `tracklang.sty`. Combined with `pull-request.yaml`'s `build-pdf` job already passing in CI today (via the transitive `texlive-xetex` → `texlive-latex-extra` path), I'm confident this explicit, additive change is safe for the CI runners and doesn't risk regressing a currently-green build.
