### PR TITLE
Fix broken link, stop retrying rate-limited otterbox.com in link-check

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -339,6 +339,12 @@ linkcheck_allowed_redirects = {
 # is IP-reputation-based blocking, not a request-volume rate limit, so no
 # amount of waiting resolves it. Without this, each link burns the full
 # linkcheck_rate_limit_timeout backoff every run before being marked broken.
+# www.otterbox.com (confirmed 7/2026) 429s every request from CI IP ranges and
+# keeps resending a fresh Retry-After on each retry, so Sphinx's rate-limit
+# backoff never hits linkcheck_rate_limit_timeout and just sleeps indefinitely
+# -- one PR run spent 31 minutes retrying this single link before eventually
+# succeeding. Not reproducible from a non-CI IP (resolves instantly there),
+# confirming this is IP-reputation blocking, not a real outage.
 
 linkcheck_ignore = [
    r'https://my.firstinspires.org/Dashboard/',
@@ -357,6 +363,7 @@ linkcheck_ignore = [
    r'https://www.pitsco.com/',
    r'https://www.studica.com/',
    r'https://www.rcmart.com/',
+   r'https://www.otterbox.com/',
    r'https://docutils\.sourceforge\.io/',
    r'https://www\.w3\.org/WAI/',
    r'https://www.3dflow.net/',

--- a/docs/source/control_system_troubleshooting/monitoring_wireless_environment/monitoring-wireless-environment.rst
+++ b/docs/source/control_system_troubleshooting/monitoring_wireless_environment/monitoring-wireless-environment.rst
@@ -73,8 +73,8 @@ in monitoring activity on the wireless spectrum.
 Wi-Fi Analyzer
 -----------------
 
-`Wi-Fi Analyzer <https://play.google.com/store/apps/details?id=com.farproc.wifi.analyzer&hl=en>`__
-is a free app, available on the Google Play store, that you can install
+`Wi-Fi Analyzer <https://play.google.com/store/apps/details?id=com.vrem.wifianalyzer&hl=en>`__
+is a free, open-source app, available on the Google Play store, that you can install
 onto an Android device. It lets you see what wireless networks are
 operating in your venue, with a graphical display that overlays the
 available networks onto a graph of operating channels and shows the


### PR DESCRIPTION
## Summary

Should merge before #416, which currently also shows a slow/failing `link-check` job for these same reasons.

| Issue | Evidence | Fix |
|---|---|---|
| `farproc` Wi-Fi Analyzer app link is dead | `curl` → `404`; app confirmed discontinued (removed from Play Store) | Swapped to [WiFi Analyzer (open-source) by VREM](https://play.google.com/store/apps/details?id=com.vrem.wifianalyzer&hl=en) — live, actively maintained, verified via `curl` before use, same free/on-device functionality described in the doc |
| `www.otterbox.com` burns ~31 minutes per CI run | CI log shows 31 consecutive `-rate limited- ... sleeping...` cycles (~60s apart) before finally resolving; same URL resolves instantly with no rate limiting from a non-CI IP | Added `www.otterbox.com` to `linkcheck_ignore`, following the existing dated-comment convention for AndyMark/Pitsco/Studica/RCMart (same IP-reputation-blocking pattern, not a real outage) |

## Test plan
Ran a full standalone `linkcheck` (not the PR's `linkcheckdiff` diff-only builder) via `nix develop`, before and after:
- Before: 1 genuinely broken link (Play Store 404) + otterbox stuck in an unbounded retry loop, ~37 minutes total wall time
- After: 0 broken links, full run in under 2 minutes
- `sphinx -b html -W` build still succeeds with no new warnings; confirmed the new Play Store link renders correctly in the built HTML

Not in scope for this PR (non-blocking, noted for visibility): two `www.hp.com` product URLs in `laptops.rst` consistently time out (confirmed from both CI and a local IP — a real slow/hanging server, not IP-reputation blocking), and there are ~53 external links returning ordinary 301/302 redirects. Neither fails the `link-check` job today (only `broken` status does), so left alone to keep this PR focused.

- [ ] Confirm `link-check` passes and finishes quickly on this PR
- [ ] Confirm no other jobs regressed