### PR TITLE
Replace magic-nix-cache-action with cache-nix-action to avoid GH Actions cache rate limiting

### DIFF
--- a/.github/workflows/booklets.yaml
+++ b/.github/workflows/booklets.yaml
@@ -20,8 +20,11 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
 
-      - name: Set up Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@v14
+      - name: Restore and cache Nix store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock') }}
+          gc-max-store-size-linux: 9G
 
       - name: Build Booklets
         env:

--- a/.github/workflows/link-check.yaml
+++ b/.github/workflows/link-check.yaml
@@ -15,8 +15,11 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
 
-      - name: Set up Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@v14
+      - name: Restore and cache Nix store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock') }}
+          gc-max-store-size-linux: 9G
 
       - name: link-check
         run: nix develop -c make -C docs/ linkcheckdiff SPHINXOPTS="--keep-going"

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -13,8 +13,11 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
 
-      - name: Set up Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@v14
+      - name: Restore and cache Nix store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock') }}
+          gc-max-store-size-linux: 9G
 
       - name: Build PDF
         env:
@@ -42,8 +45,11 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
 
-      - name: Set up Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@v14
+      - name: Restore and cache Nix store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock') }}
+          gc-max-store-size-linux: 9G
 
       - name: Build Site
         env:
@@ -77,8 +83,11 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
 
-      - name: Set up Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@v14
+      - name: Restore and cache Nix store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock') }}
+          gc-max-store-size-linux: 9G
 
       - name: Install additional dependencies
         run: |
@@ -143,8 +152,11 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
 
-      - name: Set up Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@v14
+      - name: Restore and cache Nix store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock') }}
+          gc-max-store-size-linux: 9G
 
       - name: image-check
         run: nix develop -c make -C docs/ imagecheck
@@ -161,8 +173,11 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
 
-      - name: Set up Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@v14
+      - name: Restore and cache Nix store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock') }}
+          gc-max-store-size-linux: 9G
 
       - name: check-redirect
         run: nix develop -c make -C docs/ rediraffecheckdiff


### PR DESCRIPTION
## Summary

`magic-nix-cache-action` uploads one GitHub Actions cache entry **per Nix store path** — thousands of them for this flake's `texlive.combine { scheme-full }` closure alone. GitHub now hard-limits Actions cache to **200 new-entry uploads/minute per repo** ([changelog](https://github.blog/changelog/2026-01-16-rate-limiting-for-actions-cache-entries/), [confirmed by GitHub staff on the Nix project](https://github.com/nixos/nix/issues/15016)), specifically to stop this kind of "cache thrashing." Any job touching our texlive closure blows through that limit almost immediately, gets throttled (`HTTP 418` / `ResourceExhausted`), and `magic-nix-cache-action` gives up on caching for the rest of that run:

```
error: unable to download '.../....narinfo': HTTP error 418
response body: GitHub API error: GitHub Actions Cache throttled Magic Nix Cache. Not trying to use it again on this run.
```
— visible as `error: substituter '...' is disabled` spam and everything rebuilding from scratch instead of restoring from cache. This is almost certainly why `build-pdf` consistently takes 10-13 minutes.

## Fix

Swap to [`nix-community/cache-nix-action`](https://github.com/nix-community/cache-nix-action), which:
- Saves/restores the whole `/nix` store as **one cache entry per key** (a single upload, not thousands) — not subject to the same per-entry rate limit.
- Properly merges Nix's SQLite path-registration DB on restore (not just a naive file copy — otherwise Nix wouldn't trust the restored paths and would rebuild anyway).
- Runs `nix store gc` before saving (`gc-max-store-size-linux: 9G`) to stay under the 10GB per-entry cache size cap — our current live closure is ~7.4GB, checked locally via `nix path-info -rS`.
- Cache key is `hashFiles('flake.nix', 'flake.lock')`, so it only invalidates when the flake's actual inputs change, not on every commit.

Applied to all three workflows that use the flake: `pull-request.yaml` (5 jobs), `booklets.yaml`, `link-check.yaml`.

## Test plan
This needs at least two real CI runs to prove out (first run establishes/saves the cache cold, second run should show a fast restore):
- [ ] First run: confirm the store saves successfully as a single cache entry, no rate-limit errors
- [ ] Second run (e.g. an empty commit or re-run): confirm the cache actually restores and jobs run meaningfully faster, especially `build-pdf`
- [ ] Confirm no `substituter ... is disabled` spam in any job log
- [ ] Confirm all jobs still pass