### PR TITLE
Scaffold Robot Best Practices article as separate includable sub-sections

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -92,6 +92,7 @@ and :doc:`gracious_professionalism/gp` to see why.
    Control System Troubleshooting Guide <control_system_troubleshooting/index>
    Managing ESD Effects <hardware_and_software_configuration/configuring/managing_esd/managing-esd>
    Robot Wiring Guide <robot_building/wiring_guide/wiring-guide>
+   Robot Best Practices <robot_building/best_practices/robot-best-practices>
 
 .. toctree::
    :caption: Manufacturing

--- a/docs/source/robot_building/best_practices/battery-mounting.rst
+++ b/docs/source/robot_building/best_practices/battery-mounting.rst
@@ -1,0 +1,7 @@
+Battery Mounting Best Practices
+----------------------------------
+
+.. todo::
+   Add battery mounting best practices content.
+
+See the :doc:`Robot Wiring Guide <../wiring_guide/wiring-guide>` for related battery security guidance.

--- a/docs/source/robot_building/best_practices/control-system-software-management.rst
+++ b/docs/source/robot_building/best_practices/control-system-software-management.rst
@@ -1,0 +1,5 @@
+Control System Software Management Best Practices
+----------------------------------------------------
+
+.. todo::
+   Add control system software management best practices content.

--- a/docs/source/robot_building/best_practices/gamepad.rst
+++ b/docs/source/robot_building/best_practices/gamepad.rst
@@ -1,0 +1,5 @@
+Gamepad Best Practices
+------------------------
+
+.. todo::
+   Add gamepad best practices content.

--- a/docs/source/robot_building/best_practices/power-management.rst
+++ b/docs/source/robot_building/best_practices/power-management.rst
@@ -1,0 +1,7 @@
+Power Management Best Practices
+---------------------------------
+
+.. todo::
+   Add power management best practices content.
+
+See the :doc:`Power Distribution <../../control_hard_compon/rc_components/power_distr/power-distr>` page for background on power ports.

--- a/docs/source/robot_building/best_practices/robot-best-practices.rst
+++ b/docs/source/robot_building/best_practices/robot-best-practices.rst
@@ -1,0 +1,29 @@
+.. meta::
+   :title: Robot Best Practices
+   :description: Best practices for building a reliable FIRST Tech Challenge robot, covering servo power, power management, grounding, controller mounting, wiring, software management, gamepads, battery mounting, and smartphones.
+   :keywords: FTC Docs, FIRST Tech Challenge, FTC, best practices, servo power, power management, grounding, robot controller mounting, wiring, control system software, gamepad, battery mounting, smartphone
+
+Robot Best Practices
+=====================
+
+This article collects best practices for building a reliable *FIRST* Tech
+Challenge robot. Each section below covers a specific area of robot design
+and can be read independently.
+
+.. include:: servo-power-usage.rst
+
+.. include:: power-management.rst
+
+.. include:: robot-grounding.rst
+
+.. include:: robot-controller-mounting.rst
+
+.. include:: robot-wiring.rst
+
+.. include:: control-system-software-management.rst
+
+.. include:: gamepad.rst
+
+.. include:: battery-mounting.rst
+
+.. include:: smartphone.rst

--- a/docs/source/robot_building/best_practices/robot-controller-mounting.rst
+++ b/docs/source/robot_building/best_practices/robot-controller-mounting.rst
@@ -1,0 +1,5 @@
+Robot Controller Mounting Best Practices
+------------------------------------------
+
+.. todo::
+   Add robot controller mounting best practices content.

--- a/docs/source/robot_building/best_practices/robot-grounding.rst
+++ b/docs/source/robot_building/best_practices/robot-grounding.rst
@@ -1,0 +1,7 @@
+Robot Grounding Best Practices
+--------------------------------
+
+.. todo::
+   Add robot grounding best practices content.
+
+See :doc:`Managing ESD Effects <../../hardware_and_software_configuration/configuring/managing_esd/managing-esd>` for more detail on grounding straps and electrostatic discharge mitigation.

--- a/docs/source/robot_building/best_practices/robot-wiring.rst
+++ b/docs/source/robot_building/best_practices/robot-wiring.rst
@@ -1,0 +1,7 @@
+Robot Wiring Best Practices
+-----------------------------
+
+.. todo::
+   Add robot wiring best practices content.
+
+See the :doc:`Robot Wiring Guide <../wiring_guide/wiring-guide>` for a full guide on wire management, strain relief, and connectors.

--- a/docs/source/robot_building/best_practices/servo-power-usage.rst
+++ b/docs/source/robot_building/best_practices/servo-power-usage.rst
@@ -1,0 +1,7 @@
+Servo Power Usage Best Practices
+---------------------------------
+
+.. todo::
+   Add servo power usage best practices content.
+
+See the :doc:`Servos <../../control_hard_compon/rc_components/servos/servos>` page for background on servo ports and power.

--- a/docs/source/robot_building/best_practices/smartphone.rst
+++ b/docs/source/robot_building/best_practices/smartphone.rst
@@ -1,0 +1,5 @@
+Smartphone Best Practices
+----------------------------
+
+.. todo::
+   Add smartphone best practices content.


### PR DESCRIPTION
## Summary
- Adds a new **Robot Best Practices** page composed of 9 independently-editable sub-section files (Servo Power Usage, Power Management, Robot Grounding, Robot Controller Mounting, Robot Wiring, Control System Software Management, Gamepad, Battery Mounting, Smartphone), combined into the parent page via `.. include::` directives so multiple contributors can work on different sections without conflicting.
- Wires the new page into the `Guides` toctree in `index.rst`, alongside the existing Robot Wiring Guide and Managing ESD Effects pages.
- For sub-sections that overlap existing pages (Robot Wiring, Battery Mounting, Robot Grounding, Servo Power Usage), the stub links out to the existing detailed guide instead of duplicating content.
- This PR is structure only — each sub-section file currently contains a `.. todo::` placeholder; actual best-practices content will be filled in in follow-up PRs per section.

## Test plan
- [x] Built the full docs site locally with `sphinx-build` — build succeeded with no new warnings or errors
- [x] Verified all 9 sub-section pages render and are correctly included in the parent page
- [x] Verified cross-reference links to existing pages (wiring guide, ESD, servos, power distribution) resolve correctly
- [ ] Content review for each sub-section once written

🤖 Generated with [Claude Code](https://claude.com/claude-code)