### PR TITLE
Add AprilTag Clusters Tech Tip stub

### DIFF
--- a/docs/source/tech_tips/tech-tips.rst
+++ b/docs/source/tech_tips/tech-tips.rst
@@ -63,6 +63,7 @@ Software and Programming
    tech-tips/tech-tip-protecting-robot-code/tech-tip-protecting-robot-code
    tech-tips/tech-tip-vision-resources/tech-tip-vision-resources
    tech-tips/tech-tip-google-ai-studio/tech-tip-google-ai-studio
+   tech-tips/tech-tip-apriltag-clusters/tech-tip-apriltag-clusters
 
 Competition and Team Resources
 ------------------------------

--- a/docs/source/tech_tips/tech-tips/tech-tip-apriltag-clusters/tech-tip-apriltag-clusters.rst
+++ b/docs/source/tech_tips/tech-tips/tech-tip-apriltag-clusters/tech-tip-apriltag-clusters.rst
@@ -1,0 +1,21 @@
+AprilTag Clusters
+==================
+
+Started in the 2023-2024 season, Tech Tips are a segment released in the
+*FIRST* Tech Challenge `Team E-mail Blast
+<https://www.firstinspires.org/resources/library/ftc/team-email-blast-archive>`__.
+Sometimes the Tech Tips are included in whole in the email blast, but sometimes
+there is more content than is reasonable in the email blast so partial content
+is included in the blast with the rest of the content here.
+
+.. _apriltagclusters:
+
+A new feature released in FTC SDK 12.0 is AprilTag Clusters. This is a technique
+that groups multiple AprilTags together for mult-tag object and camera tracking.
+The full details of how this feature is important to BIOBUZZ will be published
+here soon. This text is here only as a stub until after kickoff.
+
+.. note::
+   This Tech Tip has not been fully published yet. It is scheduled to be released
+   online on Monday, September 14, 2026, and this page will be filled in with the 
+   full content at that time.


### PR DESCRIPTION
## Summary
- Adds a placeholder page for the upcoming "AprilTag Clusters" Tech Tip (new in FTC SDK 12.0) so the page exists ahead of publication.
- The stub intentionally omits feature details since this is a public repo and the tip is embargoed until the Team E-mail Blast goes out.
- Wires the new page into the `tech-tips.rst` toctree under "Software and Programming", next to the existing vision-related tip.

## Notes for reviewers
- This is a stub only — full content will be added in a follow-up PR once the Tech Tip publishes on **Monday, September 14, 2026**.
- Verified the docs build successfully (Sphinx 8.2.3 via the repo's `.venv`) with no warnings/errors on the new page.

## Test plan
- [ ] Confirm the stub language and scheduled date read correctly before Monday's release
- [ ] Follow up with the full AprilTag Clusters content once published